### PR TITLE
Bumping cosmos-SDK version to v0.39.0 LTS, persistenceSDK ready for first version tag.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Shopify/sarama v1.19.0
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
 	github.com/bartekn/go-bip39 v0.0.0-20171116152956-a05967ea095d
-	github.com/cosmos/cosmos-sdk v0.39.1-0.20200727135228-9d00f712e334
+	github.com/cosmos/cosmos-sdk v0.39.0
 	github.com/gorilla/mux v1.7.4
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0


### PR DESCRIPTION
Code stabilised:
* Blackbox and performance tested
* Unit tested

Ready for v0.1.0 release