### PR TITLE
truncating Dec in splits as done in int, to maintain correctness.

### DIFF
--- a/modules/splits/internal/transactions/unwrap/keeper.go
+++ b/modules/splits/internal/transactions/unwrap/keeper.go
@@ -39,7 +39,7 @@ func (transactionKeeper transactionKeeper) Transact(context sdkTypes.Context, ms
 	if split == nil {
 		return newTransactionResponse(errors.EntityNotFound)
 	}
-	split = split.(mappables.Split).Send(message.Split).(mappables.Split)
+	split = split.(mappables.Split).Send(message.Split.TruncateDec()).(mappables.Split)
 	if split.(mappables.Split).GetSplit().LT(sdkTypes.ZeroDec()) {
 		return newTransactionResponse(errors.InsufficientBalance)
 	} else if split.(mappables.Split).GetSplit().Equal(sdkTypes.ZeroDec()) {

--- a/modules/splits/internal/transactions/unwrap/keeper_test.go
+++ b/modules/splits/internal/transactions/unwrap/keeper_test.go
@@ -114,7 +114,7 @@ func Test_transactionKeeper_Transact(t *testing.T) {
 
 	t.Run("PositiveCase- Send All", func(t *testing.T) {
 		want := newTransactionResponse(nil)
-		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, fromID, ownableID, sdkTypes.NewDec(1000))); !reflect.DeepEqual(got, want) {
+		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, fromID, ownableID, sdkTypes.NewInt(1000))); !reflect.DeepEqual(got, want) {
 			t.Errorf("Transact() = %v, want %v", got, want)
 		}
 	})
@@ -125,7 +125,7 @@ func Test_transactionKeeper_Transact(t *testing.T) {
 
 	t.Run("PositiveCase", func(t *testing.T) {
 		want := newTransactionResponse(nil)
-		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, fromID, ownableID, sdkTypes.NewDec(10))); !reflect.DeepEqual(got, want) {
+		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, fromID, ownableID, sdkTypes.NewInt(10))); !reflect.DeepEqual(got, want) {
 			t.Errorf("Transact() = %v, want %v", got, want)
 		}
 	})
@@ -133,7 +133,7 @@ func Test_transactionKeeper_Transact(t *testing.T) {
 	t.Run("NegativeCase-Verify Identity Failure", func(t *testing.T) {
 		t.Parallel()
 		want := newTransactionResponse(errors.MockError)
-		if got := keepers.SplitsKeeper.Transact(context, newMessage(verifyMockErrorAddress, fromID, ownableID, sdkTypes.NewDec(10))); !reflect.DeepEqual(got, want) {
+		if got := keepers.SplitsKeeper.Transact(context, newMessage(verifyMockErrorAddress, fromID, ownableID, sdkTypes.NewInt(10))); !reflect.DeepEqual(got, want) {
 			t.Errorf("Transact() = %v, want %v", got, want)
 		}
 	})
@@ -141,7 +141,7 @@ func Test_transactionKeeper_Transact(t *testing.T) {
 	t.Run("NegativeCase-Send Negative Balance", func(t *testing.T) {
 		t.Parallel()
 		want := newTransactionResponse(errors.NotAuthorized)
-		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, fromID, ownableID, sdkTypes.NewDec(-10))); !reflect.DeepEqual(got, want) {
+		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, fromID, ownableID, sdkTypes.NewInt(-10))); !reflect.DeepEqual(got, want) {
 			t.Errorf("Transact() = %v, want %v", got, want)
 		}
 	})
@@ -149,7 +149,7 @@ func Test_transactionKeeper_Transact(t *testing.T) {
 	t.Run("NegativeCase-Send More than own Balance", func(t *testing.T) {
 		t.Parallel()
 		want := newTransactionResponse(errors.InsufficientBalance)
-		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, fromID, ownableID, sdkTypes.NewDec(10000))); !reflect.DeepEqual(got, want) {
+		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, fromID, ownableID, sdkTypes.NewInt(10000))); !reflect.DeepEqual(got, want) {
 			t.Errorf("Transact() = %v, want %v", got, want)
 		}
 	})
@@ -157,7 +157,7 @@ func Test_transactionKeeper_Transact(t *testing.T) {
 	t.Run("NegativeCase-Split Not found", func(t *testing.T) {
 		t.Parallel()
 		want := newTransactionResponse(errors.EntityNotFound)
-		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, base.NewID("id"), ownableID, sdkTypes.NewDec(10))); !reflect.DeepEqual(got, want) {
+		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, base.NewID("id"), ownableID, sdkTypes.NewInt(10))); !reflect.DeepEqual(got, want) {
 			t.Errorf("Transact() = %v, want %v", got, want)
 		}
 	})
@@ -166,7 +166,7 @@ func Test_transactionKeeper_Transact(t *testing.T) {
 	require.Equal(t, nil, Error)
 	t.Run("NegativeCase-Module does not have enough coins", func(t *testing.T) {
 		want := newTransactionResponse(errors.InsufficientBalance)
-		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, fromID, ownableID, sdkTypes.NewDec(200))); !reflect.DeepEqual(got.IsSuccessful(), want.IsSuccessful()) {
+		if got := keepers.SplitsKeeper.Transact(context, newMessage(defaultAddr, fromID, ownableID, sdkTypes.NewInt(200))); !reflect.DeepEqual(got.IsSuccessful(), want.IsSuccessful()) {
 			t.Errorf("Transact() = %v, want %v", got, want)
 		}
 	})

--- a/modules/splits/internal/transactions/unwrap/message.go
+++ b/modules/splits/internal/transactions/unwrap/message.go
@@ -22,7 +22,7 @@ type message struct {
 	From      sdkTypes.AccAddress `json:"from" valid:"required~required field from missing matches(^commit[a-z0-9]{39}$)~invalid field from"`
 	FromID    types.ID            `json:"fromID" valid:"required~required field fromID missing"`
 	OwnableID types.ID            `json:"ownableID" valid:"required~required field ownableID missing"`
-	Split     sdkTypes.Dec        `json:"split" valid:"required~required field split missing"`
+	Split     sdkTypes.Int        `json:"split" valid:"required~required field split missing"`
 }
 
 var _ sdkTypes.Msg = message{}
@@ -57,7 +57,7 @@ func messagePrototype() helpers.Message {
 	return message{}
 }
 
-func newMessage(from sdkTypes.AccAddress, fromID types.ID, ownableID types.ID, split sdkTypes.Dec) sdkTypes.Msg {
+func newMessage(from sdkTypes.AccAddress, fromID types.ID, ownableID types.ID, split sdkTypes.Int) sdkTypes.Msg {
 	return message{
 		From:      from,
 		FromID:    fromID,

--- a/modules/splits/internal/transactions/unwrap/message_test.go
+++ b/modules/splits/internal/transactions/unwrap/message_test.go
@@ -18,7 +18,7 @@ func Test_Unwrap_Message(t *testing.T) {
 
 	testFromID := base.NewID("fromID")
 	testOwnableID := base.NewID("ownableID")
-	testSplit := sdkTypes.NewDec(2)
+	testSplit := sdkTypes.NewInt(2)
 
 	fromAddress := "cosmos1pkkayn066msg6kn33wnl5srhdt3tnu2vzasz9c"
 	fromAccAddress, Error := sdkTypes.AccAddressFromBech32(fromAddress)

--- a/modules/splits/internal/transactions/unwrap/request.go
+++ b/modules/splits/internal/transactions/unwrap/request.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdkTypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/rest"
+	xprtErrors "github.com/persistenceOne/persistenceSDK/constants/errors"
 	"github.com/persistenceOne/persistenceSDK/constants/flags"
 	"github.com/persistenceOne/persistenceSDK/modules/splits/internal/module"
 	"github.com/persistenceOne/persistenceSDK/schema/helpers"
@@ -23,7 +24,7 @@ type transactionRequest struct {
 	BaseReq   rest.BaseReq `json:"baseReq"`
 	FromID    string       `json:"fromID" valid:"required~required field fromID missing matches(^[A-Za-z]$)~invalid field fromID"`
 	OwnableID string       `json:"ownableID" valid:"required~required field ownableID missing matches(^[A-Za-z]$)~invalid field ownableID"`
-	Split     string       `json:"split" valid:"required~required field split missing matches(^[A-Za-z]$)~invalid field split"`
+	Split     string       `json:"split" valid:"required~required field split missing"`
 }
 
 var _ helpers.TransactionRequest = (*transactionRequest)(nil)
@@ -55,11 +56,10 @@ func (transactionRequest transactionRequest) MakeMsg() (sdkTypes.Msg, error) {
 		return nil, Error
 	}
 
-	split, Error := sdkTypes.NewDecFromStr(transactionRequest.Split)
-	if Error != nil {
-		return nil, Error
+	split, ok := sdkTypes.NewIntFromString(transactionRequest.Split)
+	if !ok {
+		return nil, xprtErrors.InvalidRequest
 	}
-
 	return newMessage(
 		from,
 		base.NewID(transactionRequest.FromID),

--- a/modules/splits/internal/transactions/unwrap/request_test.go
+++ b/modules/splits/internal/transactions/unwrap/request_test.go
@@ -12,6 +12,7 @@ import (
 	sdkTypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
+	xprtErrors "github.com/persistenceOne/persistenceSDK/constants/errors"
 	"github.com/persistenceOne/persistenceSDK/constants/flags"
 	"github.com/persistenceOne/persistenceSDK/schema"
 	"github.com/persistenceOne/persistenceSDK/schema/helpers"
@@ -58,11 +59,15 @@ func Test_Unwrap_Request(t *testing.T) {
 	require.Equal(t, testBaseReq, testTransactionRequest.GetBaseReq())
 
 	msg, Error := testTransactionRequest.MakeMsg()
-	require.Equal(t, newMessage(fromAccAddress, base.NewID("fromID"), base.NewID("ownableID"), sdkTypes.NewDec(2)), msg)
+	require.Equal(t, newMessage(fromAccAddress, base.NewID("fromID"), base.NewID("ownableID"), sdkTypes.NewInt(2)), msg)
 	require.Nil(t, Error)
 
 	msg2, Error := newTransactionRequest(rest.BaseReq{From: "randomFromAddress", ChainID: "test"}, "fromID", "ownableID", "2").MakeMsg()
 	require.NotNil(t, Error)
+	require.Nil(t, msg2)
+
+	msg2, Error = newTransactionRequest(rest.BaseReq{From: fromAddress, ChainID: "test"}, "fromID", "ownableID", "2.5").MakeMsg()
+	require.Equal(t, xprtErrors.InvalidRequest, Error)
 	require.Nil(t, msg2)
 
 	msg2, Error = newTransactionRequest(testBaseReq, "fromID", "ownableID", "randomString").MakeMsg()


### PR DESCRIPTION
closes #177 , should ideally change transaction message type to only allow int/ sdk.Coins