### PR TITLE
adding test case to cover EntityNotFound error.

### DIFF
--- a/modules/classifications/auxiliaries/conform/keeper_test.go
+++ b/modules/classifications/auxiliaries/conform/keeper_test.go
@@ -113,4 +113,12 @@ func Test_Auxiliary_Keeper_Help(t *testing.T) {
 		}
 	})
 
+	t.Run("NegativeCase- Classification EntityNotFound", func(t *testing.T) {
+		t.Parallel()
+		want := newAuxiliaryResponse(errors.EntityNotFound)
+		if got := keepers.ClassificationsKeeper.Help(context, NewAuxiliaryRequest(base.NewID("test.classification"), immutables, base.NewMutables(base.NewProperties(base.NewProperty(base.NewID("ID6"), base.NewFact(base.NewStringData("Data3"))))))); !reflect.DeepEqual(got, want) {
+			t.Errorf("Transact() = %v, want %v", got, want)
+		}
+	})
+
 }


### PR DESCRIPTION
closes #129 , intended code, if ID is not of correct format, it is parsed as partial ID, and returned.