### PR TITLE
removing fromID flag from reveal meta txn.

### DIFF
--- a/modules/metas/internal/transactions/reveal/transaction.go
+++ b/modules/metas/internal/transactions/reveal/transaction.go
@@ -18,6 +18,5 @@ var Transaction = base.NewTransaction(
 	requestPrototype,
 	messagePrototype,
 	keeperPrototype,
-	flags.FromID,
 	flags.MetaFact,
 )


### PR DESCRIPTION
FromID flag was not being used in metas reveal transaction.